### PR TITLE
1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Changelog
 
+#### Version 1.0.4
+
+* Handle faulty XML files with extra null byte
+* Add Laser geometry
+* Handle encoded thumbnail file names
+* Do not return fixture type when requesting a geometry
+* Add additional BeamTypes
+* Make channels optional in get_dmx_modes_info
+* Add python dev versions to tests
+* Improved channel/function defaults, added highlights
+
 #### Version 1.0.3
 * First release under Open-Stage organization
     * add CI/CD pytest testing + mypy

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 * generate wheel:
 
 ```bash
+python -m pip install setuptools wheel
 python3 setup.py sdist bdist_wheel
 ```
 * test upload to TestPypi with twine

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pygdtf",
-    version="1.0.3",
+    version="1.0.4",
     description="General Device Type Format library for Python",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
#### Version 1.0.4

* Handle faulty XML files with extra null byte
* Add Laser geometry
* Handle encoded thumbnail file names
* Do not return fixture type when requesting a geometry
* Add additional BeamTypes
* Make channels optional in get_dmx_modes_info
* Add python dev versions to tests
* Improved channel/function defaults, added highlights